### PR TITLE
Migrate tests to JUnit 5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <wildfly.version>25.0.1.Final</wildfly.version>
         <tomee9.version>9.0.0-M7</tomee9.version>
         <liberty.version>21.0.0.12</liberty.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -96,15 +97,20 @@
 
         <!-- Test dependencies.	-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -142,6 +148,14 @@
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>1.7.0.Alpha10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.8.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -276,6 +290,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven-surefire-plugin.version}</version>
+            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -397,6 +417,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <systemPropertyVariables>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -442,7 +463,9 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <argLine>-DTOMEE_LOCK_FILE=${user.dir}/.tomee-ports.lock</argLine>
                             <systemPropertyVariables>
@@ -531,6 +554,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <systemPropertyVariables>
                                 <arquillian.launch>liberty</arquillian.launch>

--- a/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
+++ b/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
@@ -41,19 +41,19 @@ public class PooledTest {
 	@Deployment
 	public static Archive<?> createDeployment() {
 		return create(WebArchive.class)
-                 .addAsManifestResource(INSTANCE, "beans.xml")
-                 .addClasses(SingleInstancePooledBean.class)
-                 .addAsLibraries(create(JavaArchive.class)
-                         .addAsManifestResource(INSTANCE, "beans.xml")
-                         .addAsServiceProvider(Extension.class, PooledExtension.class)
-                         .addPackages(true, "org.omnifaces.services.pooled")
-                         .addPackages(true, "org.omnifaces.services.util")
-                         )
-                 .addAsLibraries(Maven.resolver()
-                         .loadPomFromFile("pom.xml")
-                         .resolve("org.omnifaces:omniutils")
-                         .withoutTransitivity()
-                         .asSingleFile());
+				.addAsManifestResource(INSTANCE, "beans.xml")
+				.addClasses(SingleInstancePooledBean.class)
+				.addAsLibraries(create(JavaArchive.class)
+						.addAsManifestResource(INSTANCE, "beans.xml")
+						.addAsServiceProvider(Extension.class, PooledExtension.class)
+						.addPackages(true, "org.omnifaces.services.pooled")
+						.addPackages(true, "org.omnifaces.services.util")
+				)
+				.addAsLibraries(Maven.resolver()
+				                     .loadPomFromFile("pom.xml")
+				                     .resolve("org.omnifaces:omniutils")
+				                     .withoutTransitivity()
+				                     .asSingleFile());
 	}
 
 	@Inject
@@ -68,7 +68,8 @@ public class PooledTest {
 	}
 
 	@Test
-	@DisplayName("with an invocation that throws an exception not in the destroyOn field does not destroy the instance.")
+	@DisplayName(
+			"with an invocation that throws an exception not in the destroyOn field does not destroy the instance.")
 	public void bean_withInvocationThrowingANonDestroyingException_doesNotDestroyInstance() {
 		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
 
@@ -78,18 +79,21 @@ public class PooledTest {
 	}
 
 	@Test
-	@DisplayName("with an invocation that throws an exception explicitly listed in the dontDestroyOn field does not destroy the instance.")
+	@DisplayName(
+			"with an invocation that throws an exception explicitly listed in the dontDestroyOn field does not destroy the instance.")
 	public void bean_withInvocationThrowingAnExplicitNonDestroyingException_doesNotDestroyInstance() {
 		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
 
-		assertThrows(IllegalArgumentException.class, () -> singleInstancePooledBean.throwException(IllegalArgumentException::new));
+		assertThrows(IllegalArgumentException.class,
+				() -> singleInstancePooledBean.throwException(IllegalArgumentException::new));
 
 		assertEquals(identityHashCode, singleInstancePooledBean.getIdentityHashCode());
 	}
 
 
 	@Test
-	@DisplayName("with an invocation that throws an exception explicitly listed in the destroyOn field destroys the instance.")
+	@DisplayName(
+			"with an invocation that throws an exception explicitly listed in the destroyOn field destroys the instance.")
 	public void bean_withInvocationThrowingAnExplicitDestroyingException_destroysInstance() {
 		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
 

--- a/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
+++ b/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
@@ -16,6 +16,7 @@ import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
@@ -59,37 +60,40 @@ public class PooledTest {
 	private SingleInstancePooledBean singleInstancePooledBean;
 
 	@Test
-	public void testPooledBean() {
+	@DisplayName("with a single instance configured will always returns the same instance.")
+	public void bean_withASingleInstanceConfigured_willAlwaysCauseSameInstanceToBeUsed() {
 		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
 
 		assertEquals(identityHashCode, singleInstancePooledBean.getIdentityHashCode());
 	}
 
 	@Test
-	public void testDestroyOn() {
+	@DisplayName("with an invocation that throws an exception not in the destroyOn field does not destroy the instance.")
+	public void bean_withInvocationThrowingANonDestroyingException_doesNotDestroyInstance() {
 		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
 
-		try {
-			singleInstancePooledBean.throwException(Exception::new);
-		}
-		catch (Exception e) {
-		}
+		assertThrows(Exception.class, () -> singleInstancePooledBean.throwException(Exception::new));
 
 		assertEquals(identityHashCode, singleInstancePooledBean.getIdentityHashCode());
+	}
 
-		try {
-			singleInstancePooledBean.throwException(IllegalArgumentException::new);
-		}
-		catch (IllegalArgumentException e) {
-		}
+	@Test
+	@DisplayName("with an invocation that throws an exception explicitly listed in the dontDestroyOn field does not destroy the instance.")
+	public void bean_withInvocationThrowingAnExplicitNonDestroyingException_doesNotDestroyInstance() {
+		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
+
+		assertThrows(IllegalArgumentException.class, () -> singleInstancePooledBean.throwException(IllegalArgumentException::new));
 
 		assertEquals(identityHashCode, singleInstancePooledBean.getIdentityHashCode());
+	}
 
-		try {
-			singleInstancePooledBean.throwException(RuntimeException::new);
-		}
-		catch (RuntimeException e) {
-		}
+
+	@Test
+	@DisplayName("with an invocation that throws an exception explicitly listed in the destroyOn field destroys the instance.")
+	public void bean_withInvocationThrowingAnExplicitDestroyingException_destroysInstance() {
+		int identityHashCode = singleInstancePooledBean.getIdentityHashCode();
+
+		assertThrows(RuntimeException.class, () -> singleInstancePooledBean.throwException(RuntimeException::new));
 
 		assertNotEquals(identityHashCode, singleInstancePooledBean.getIdentityHashCode());
 	}

--- a/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
+++ b/src/test/java/org/omnifaces/test/services/pooled/PooledTest.java
@@ -14,28 +14,31 @@ package org.omnifaces.test.services.pooled;
 
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.jboss.shrinkwrap.api.asset.EmptyAsset.INSTANCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.omnifaces.services.pooled.PooledExtension;
+import org.omnifaces.test.services.pooled.testing.DependencyInjectionArquillianExtension;
 
-
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
+@ExtendWith(DependencyInjectionArquillianExtension.class)
+@DisplayName("@Pooled")
 public class PooledTest {
 
 	@Deployment
-	public static Archive<?>  createDeployment() {
+	public static Archive<?> createDeployment() {
 		return create(WebArchive.class)
                  .addAsManifestResource(INSTANCE, "beans.xml")
                  .addClasses(SingleInstancePooledBean.class)

--- a/src/test/java/org/omnifaces/test/services/pooled/testing/DependencyInjectionArquillianExtension.java
+++ b/src/test/java/org/omnifaces/test/services/pooled/testing/DependencyInjectionArquillianExtension.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 OmniFaces
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.omnifaces.test.services.pooled.testing;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+/**
+ * JUnit extension to enable CDI based dependency injection in test instances when running in an Arquillian container.
+ */
+public class DependencyInjectionArquillianExtension implements TestInstancePostProcessor {
+
+	private static final Predicate<ExtensionContext> isInsideArquillian =
+			(context) -> context.getConfigurationParameter("insideArquillian").map(Boolean::parseBoolean).orElse(false);
+
+	@Override
+	public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) {
+		getCdi(extensionContext).ifPresent(cdi -> {
+			var beanManager = cdi.getBeanManager();
+			var testClassType = beanManager.createAnnotatedType(testInstance.getClass());
+			var injectionTargetFactory = beanManager.getInjectionTargetFactory(testClassType);
+			var injectionTarget = injectionTargetFactory.createInjectionTarget(null);
+
+			inject(injectionTarget, beanManager, testInstance);
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> void inject(InjectionTarget<T> injectionTarget, BeanManager beanManager, Object instance) {
+		injectionTarget.inject((T) instance, beanManager.createCreationalContext(null));
+	}
+
+	private static Optional<CDI<Object>> getCdi(ExtensionContext context) {
+		if (context.getConfigurationParameter("insideArquillian").map(Boolean::parseBoolean).orElse(false)) {
+			return Optional.of(CDI.current());
+		}
+
+		return Optional.empty();
+	}
+
+}


### PR DESCRIPTION
This migrates the existing tests to JUnit 5 and does some clean-up to improve the tests slightly.

This also introduces a test extension to allow injection of fields when using JUnit 5 and Arquillian containers. By default this does not appear to be supported, unlike when using JUnit 4 in combination with Arquillian.

fixes #3